### PR TITLE
fix blog link address

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Peak memory in bytes (assume each input has the same w & h):
 + Transformation: use [RANSAC](http://en.wikipedia.org/wiki/RANSAC) to estimate a homography or affine transformation.
 + Optimization: focal estimation, [bundle adjustment](https://en.wikipedia.org/wiki/Bundle_adjustment), and some straightening tricks.
 
-For details, see [my blog post](http://ppwwyyxx.com/2016/How-to-Write-a-Panorama-Stitcher/).
+For details, see [my blog post](http://ppwwyyxx.com/blog/2016/How-to-Write-a-Panorama-Stitcher/).
 
 ## Quality Guidelines
 


### PR DESCRIPTION
The old link of the article 'OpenPano: How to write a Panorama Stitcher' is nolonger available,I just fixed it.